### PR TITLE
Updated visualize() function

### DIFF
--- a/demo/robot_swarm/lsync.py
+++ b/demo/robot_swarm/lsync.py
@@ -1,3 +1,7 @@
+'''
+Author : Sarthak Das
+'''
+
 from verse.plotter.plotter2D import *
 from verse.agents.example_agent.robot_agent import RobotAgent
 from verse import Scenario

--- a/verse/analysis/analysis_tree.py
+++ b/verse/analysis/analysis_tree.py
@@ -232,11 +232,14 @@ class AnalysisTree:
 
     def visualize(self):
         G = nx.Graph()
+        f = open("traces_output.txt", "w")
         for node in self.nodes:
             G.add_node(node.id,time=(node.id,node.start_time))
             for child in node.child:
                 G.add_node(child.id,time=(child.id,child.start_time))
                 G.add_edge(node.id, child.id)
+            f.write("Node id: "+str(node.id)+", Start time: "+str(node.start_time)+"\n")
+            f.write("Mode: "+str(node.mode)+", Init: "+str(node.init)+"\n")
         labels = nx.get_node_attributes(G, 'time') 
         nx.draw_planar(G,labels=labels)
         plt.show()


### PR DESCRIPTION
In the visualize() function, the traces_output.txt of the print() function which stored the information of all the nodes in the AnalysisTree alongside the networkx visualization has been removed. This hinders the readability of the visualization.