### PR TITLE
simulate_multi() should differentiate seed values used by individual simulations

### DIFF
--- a/verse/scenario/scenario.py
+++ b/verse/scenario/scenario.py
@@ -267,7 +267,7 @@ class Scenario:
         tree_list = []
         if init_dict_list is None:
             for i in range(num_sims):
-                tree_list.append(self.simulate(time_horizon, time_step, max_height, seed + i))
+                tree_list.append(self.simulate(time_horizon, time_step, max_height, (seed + i) if seed is not None else None))
         else:
             for init_dict in init_dict_list:
                 root = AnalysisTreeNode.root_from_inits(

--- a/verse/scenario/scenario.py
+++ b/verse/scenario/scenario.py
@@ -256,7 +256,7 @@ class Scenario:
         self.past_runs.append(tree)
         return tree
 
-    def simulate_multi(self, time_horizon, time_step, init_dict_list=None, max_height=None, seed=None):
+    def simulate_multi(self, time_horizon, time_step, init_dict_list=None, max_height=None, seed=None, num_sims=10):
         '''Computes multiple simulation traces of a scenario, starting from multiple initial states.
             `seed`: the random seed for sampling a point in the region specified by the initial
             conditions
@@ -266,7 +266,7 @@ class Scenario:
         self._check_init()
         tree_list = []
         if init_dict_list is None:
-            for i in range(10):
+            for i in range(num_sims):
                 tree_list.append(self.simulate(time_horizon, time_step, max_height, seed))
         else:
             for init_dict in init_dict_list:

--- a/verse/scenario/scenario.py
+++ b/verse/scenario/scenario.py
@@ -267,7 +267,7 @@ class Scenario:
         tree_list = []
         if init_dict_list is None:
             for i in range(num_sims):
-                tree_list.append(self.simulate(time_horizon, time_step, max_height, seed))
+                tree_list.append(self.simulate(time_horizon, time_step, max_height, seed + i))
         else:
             for init_dict in init_dict_list:
                 root = AnalysisTreeNode.root_from_inits(

--- a/verse/scenario/scenario.py
+++ b/verse/scenario/scenario.py
@@ -215,13 +215,6 @@ class Scenario:
                         uncertain_parameters = agent.uncertain_parameters
                     self.set_init_single(agent_id, init_cont, init_disc, static_parameters, uncertain_parameters)  
 
-    def simulate_multi(self, time_horizon, time_step, max_height=None, num_sim=3):
-        res_list = []
-        for i in range(num_sim):
-            trace = self.simulate(time_horizon, time_step,max_height)
-            res_list.append(trace)
-        return res_list
-
     def simulate(self, time_horizon, time_step, max_height=None, seed=None) -> AnalysisTree:
         '''Computes a single simulation trace of a scenario, starting from a single initial state.
             Parameters:


### PR DESCRIPTION
The current definition of `simulate_multi()` passes the same seed to each individual calls of `simulate()`.
```python
for i in range(10):
  tree_list.append(self.simulate(time_horizon, time_step, max_height, seed))
```
 This seems to cause all simulations to start from the same initial condition when a seed is provided. I've made a preliminary change to pass `(seed + i) if seed is not None else None`, instead of `seed`, to individual simulations.
```python
for i in range(10):
  tree_list.append(self.simulate(time_horizon, time_step, max_height, (seed + i) if seed is not None else None))
```

I also removed the redefinition of `simulate_multi()`, and added an optional argument to change the number of simulations if an `init_dict` is not provided.